### PR TITLE
Remove unused `playRate` prop in Control component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -156,7 +156,6 @@ function App() {
             onVolumeSeekUp={volumeSeekUpHandler}
             mute={muted}
             onMute={muteHandler}
-            playRate={playbackRate}
             duration={formatDuration}
             currentTime={formatCurrentTime}
             onMouseSeekDown={onSeekMouseDownHandler}


### PR DESCRIPTION
**Description:**

This pull request addresses the issue of an unused `playRate` prop in the Control component. The `playRate` prop was found to be unnecessary and not utilized within the component. As a result, it has been safely removed to declutter the codebase and improve maintainability.

**Changes Made:**

- Removed the `playRate` prop declaration from the Control component.
- Removed any references to the `playRate` prop within the Control component's code.

**Additional Notes:**

- The removal of the `playRate` prop does not affect the functionality of the Control component.
- This change improves code clarity and reduces potential confusion for future developers working on this codebase.